### PR TITLE
sudo is not needed, remove it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ l-loader.bin: start.o $(BL1)
 
 ptable.img:
 	for ptable in $(PTABLE_LST); do \
-		sudo PTABLE=$${ptable} bash -x generate_ptable.sh;\
+		PTABLE=$${ptable} bash -x generate_ptable.sh;\
 		python gen_loader.py -o ptable-$${ptable}.img --img_prm_ptable=prm_ptable.img;\
 	done
 


### PR DESCRIPTION
generate_ptable.sh does not need to be run as root, so there is no
reason to use sudo.

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
Suggested-by: David Brown david.brown@linaro.org
