### PR TITLE
hikey.mk: write proper recipes for the 'loader' and 'temp' files

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -21,9 +21,13 @@ all: l-loader.bin prm_ptable.img recovery.bin
 %.o: %.S
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-l-loader.bin: start.o $(BL2)
-	$(LD) -Bstatic -Tl-loader.lds -Ttext 0xf9800800 start.o -o loader
-	$(OBJCOPY) -O binary loader temp
+loader: start.o l-loader.lds
+	$(LD) -Bstatic -Tl-loader.lds -Ttext 0xf9800800 start.o -o $@
+
+temp: loader
+	$(OBJCOPY) -O binary $< $@
+
+l-loader.bin: temp $(BL2)
 	python gen_loader_hikey.py -o $@ --img_loader=temp --img_bl1=$(BL2)
 
 prm_ptable.img:
@@ -32,12 +36,9 @@ prm_ptable.img:
 		cp prm_ptable.img ptable-$${ptable}.img;\
 	done
 
-recovery.bin: start.o $(BL1) $(NS_BL1U)
-	$(LD) -Bstatic -Tl-loader.lds -Ttext 0xf9800800 start.o -o loader
-	$(OBJCOPY) -O binary loader temp
+recovery.bin: temp $(BL1) $(NS_BL1U)
 	python gen_loader_hikey.py -o $@ --img_loader=temp --img_bl1=$(BL1) --img_ns_bl1u=$(NS_BL1U)
-	rm -f loader temp
 
 .PHONY: clean
 clean:
-	rm -f *.o l-loader.bin prm_ptable.img recovery.bin
+	rm -f *.o l-loader.bin prm_ptable.img recovery.bin loader temp


### PR DESCRIPTION
The 'loader' and 'temp' files are created and deleted by two targets
whose recipes may run concurrently (l-loader.bin and recovery.bin).
This can lead to build errors such as:

 $ make -j8 hikey ...
 [...]
 python gen_loader_hikey.py -o l-loader.bin --img_loader=temp --img_bl1=bl2.bin
 rm -f loader temp
 Traceback (most recent call last):
   File "gen_loader_hikey.py", line 181, in <module>
     main(sys.argv[1:])
   File "gen_loader_hikey.py", line 176, in main
     loader.create(img_loader, img_bl1, img_ns_bl1u, output_img)
   File "gen_loader_hikey.py", line 145, in create
     self.add(4, img_loader)
   File "gen_loader_hikey.py", line 60, in add
     fsize = os.path.getsize(fname)
   File "/usr/lib/python2.7/genericpath.py", line 57, in getsize
     return os.stat(filename).st_size
 OSError: [Errno 2] No such file or directory: 'temp'
 hikey.mk:25: recipe for target 'l-loader.bin' failed

Fix the problem by writing proper recipes for each file involved in the
build process.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>