### PR TITLE
build_uefi.sh: Some minor fixes

### DIFF
--- a/build_uefi.sh
+++ b/build_uefi.sh
@@ -1,7 +1,14 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 #
 # Usage: bash build_uefi.sh {platform}
 #
+
+# Execute bash shell if use other shell
+if [ -z "$BASH_VERSION" ]
+then
+	exec bash "$0" "$@"
+fi
 
 BUILD_OPTION=DEBUG
 #BUILD_OPTION=RELEASE
@@ -172,6 +179,9 @@ function do_symlink()
 
 function do_build()
 {
+	# unset ARCH environment variable to avoid confusion for UEFI building
+	unset ARCH
+
 	# Build edk2
 	cd ${BUILD_PATH}
 	export WORKSPACE=${BUILD_PATH}


### PR DESCRIPTION
This patch is to force the script to run with bash shell, so change
shebang. And execute bash shell if detect the script is running with
other shell.

This patch also unset 'ARCH' environment variable so avoid introduce
confusion for UEFI building.

Signed-off-by: Leo Yan <leo.yan@linaro.org>