### PR TITLE
hikey: add Trusted Board Boot feature

### DIFF
--- a/gen_loader_hikey.py
+++ b/gen_loader_hikey.py
@@ -147,8 +147,8 @@ class generator(object):
         # bl1.bin starts from 4KB
         self.add(8, img_bl1)
         if img_ns_bl1u != 0:
-            # ns_bl1u.bin starts from 96KB
-            self.add(192, img_ns_bl1u)
+            # ns_bl1u.bin starts from 160KB
+            self.add(320, img_ns_bl1u)
 
 def main(argv):
     img_ns_bl1u = 0


### PR DESCRIPTION
If user wants to build firmware with Trusted Board Boot feature,
he only need to enable TBB in build_uefi.sh script file.

And user should also clone mbedtls code in BUILD_PATH.
(http://github.com/ARMmbed/mbedtls)

When TBB is included in ARM Trusted Firmware, it needs more room
on BL1 size. So update the memory layout of BL1 RO region.

Signed-off-by: Teddy Reed <teddy@prosauce.org>
Signed-off-by: Victor Chong <victor.chong@linaro.org>
Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>