### PR TITLE
hikey.mk: Update Cross compiler variable and flags

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -1,4 +1,4 @@
-CROSS_COMPILE?=arm-linux-gnueabihf-
+CROSS_COMPILE=arm-linux-gnueabihf-
 
 ifeq ($(notdir $(CC)), clang)
 	CC=clang
@@ -7,6 +7,7 @@ ifeq ($(notdir $(CC)), clang)
 else
 	CC=$(CROSS_COMPILE)gcc
 	LD=$(CROSS_COMPILE)ld
+	CFLAGS=-mcpu=cortex-a53
 endif
 OBJCOPY=$(CROSS_COMPILE)objcopy
 


### PR DESCRIPTION
1. Use 32bit cross compiler overriding the CROSS_COMPILE variable
since that variable might already have been associated with 64bit
compiler. This is more common since the rest of the codes for Hikey
are built using 64bit cross compiler.

2. Pass CFLAGS specifying the CPU architecture to GCC for fixing
the `unknown wfi instruction` error with some compilers.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>