### PR TITLE
build_uefi.sh: upgrade arm gcc to 4.9.4

### DIFF
--- a/build_uefi.sh
+++ b/build_uefi.sh
@@ -20,7 +20,7 @@ OPTEE=1
 #TBB=1                         # Trusted Board Boot
 
 # l-loader on hikey and optee need AARCH32_GCC
-AARCH32_GCC=/opt/toolchain/gcc-linaro-arm-linux-gnueabihf-4.8-2014.01_linux/bin/
+AARCH32_GCC=/opt/toolchain/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf/bin/
 PATH=${AARCH32_GCC}:${PATH} && export PATH
 
 # Setup environment variables that are used in uefi-tools


### PR DESCRIPTION
Upgrade arm gcc to 4.9.4 since 4.8 is not available in releases.linaro.org
any more.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>