### PR TITLE
hikey.mk: add ptable-aosp-4g.img to default build

### DIFF
--- a/hikey.mk
+++ b/hikey.mk
@@ -14,7 +14,7 @@ OBJCOPY=$(CROSS_COMPILE)objcopy
 BL1=bl1.bin
 BL2=bl2.bin
 NS_BL1U=fastboot.bin
-PTABLE_LST?=aosp-8g
+PTABLE_LST?=aosp-8g aosp-4g
 
 .PHONY: all
 all: l-loader.bin prm_ptable.img recovery.bin


### PR DESCRIPTION
Generate both 8g and 4g ptable images by default at the same time to
make life easier for those with 4g boards.

Signed-off-by: Victor Chong <victor.chong@linaro.org>