### PR TITLE
build_uefi.sh: do not report error for stringop-truncation

### DIFF
--- a/build_uefi.sh
+++ b/build_uefi.sh
@@ -232,7 +232,9 @@ function do_build()
 		esac
 	fi
 	source edk2/edksetup.sh
-	make -C edk2/BaseTools
+	# refered to the commit here:
+	# https://review.trustedfirmware.org/plugins/gitiles/OP-TEE/build/+/46f7be20a128d30bb9af439ccaa69cfd872fd3c0%5E%21/#F0
+	make -C edk2/BaseTools BUILD_CC="gcc -Wno-error=stringop-truncation"
 	if [ $? != 0 ]; then
 		echo "Fail to build EDKII BaseTools ($?)"
 		exit


### PR DESCRIPTION
which refered to the commit here[1], to work around the build error reported like this:
    make[2]: Entering directory '/home/buildslave/workspace/96boards-reference-uefi-staging/118/edk2/BaseTools/Source/C/GenVtf'
    gcc  -c -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-unused-result -nostdlib -c -g  -I .. -I ../Include/Common -I ../Include/ -I ../Include/IndustryStandard -I ../Common/ -I .. -I . -I ../Include/X64/  -O2 GenVtf.c -o GenVtf.o
    GenVtf.c: In function ‘CreateFitTableAndInitialize’:
    GenVtf.c:1532:3: error: ‘strncpy’ output truncated before terminating nul copying 8 bytes from a string of the same length [-Werror=stringop-truncation]
       strncpy ((CHAR8 *) &FitStartPtr->CompAddress, FIT_SIGNATURE, 8);  // "_FIT_   "
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    GenVtf.c: In function ‘ConvertVersionInfo’:
    GenVtf.c:132:7: error: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
           strncpy (TemStr + 4 - Length, Str, Length);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    GenVtf.c:130:14: note: length computed here
         Length = strlen(Str);
                  ^~~~~~~~~~~
    cc1: all warnings being treated as errors

[1]: https://review.trustedfirmware.org/plugins/gitiles/OP-TEE/build/+/46f7be20a128d30bb9af439ccaa69cfd872fd3c0%5E%21/#F0

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>