### PR TITLE
generate_ptable.sh: increase 1024MB for system partition

### DIFF
--- a/generate_ptable.sh
+++ b/generate_ptable.sh
@@ -65,9 +65,9 @@ case ${PTABLE} in
     ${SGDISK} -n 7:0:+256M -t 7:0700 -u 7:BED8EBDC-298E-4A7A-B1F1-2500D98453B7 -c 7:"vendor" ${TEMP_FILE}
     #[8: cache: 334M-590M]
     ${SGDISK} -n 8:0:+256M -t 8:8301 -u 8:A092C620-D178-4CA7-B540-C4E26BD6D2E2 -c 8:"cache" ${TEMP_FILE}
-    #[9: system: 590M-2126M]
-    ${SGDISK} -n 9:0:+1536M -t 9:8300 -u 9:FC56E345-2E8E-49AE-B2F8-5B9D263FE377 -c 9:"system" ${TEMP_FILE}
-    #[10: userdata: 2126M-End]
+    #[9: system: 590M-3150M]
+    ${SGDISK} -n 9:0:+2560M -t 9:8300 -u 9:FC56E345-2E8E-49AE-B2F8-5B9D263FE377 -c 9:"system" ${TEMP_FILE}
+    #[10: userdata: 3150M-End]
     ${SGDISK} -n -E -t 10:8300 -u 10:064111F6-463B-4CE1-876B-13F3684CE164 -c 10:"userdata" -p ${TEMP_FILE}
     ;;
   linux-4g|linux-8g)


### PR DESCRIPTION
to work with the GSI images of various Android versions.

Here are the size information for various GSI images:
    android11-gsi vendor build out/target/product/hikey/system.img
    1281024448 5月  11 14:03 out/target/product/hikey/system.img

    aosp-android11-gsi/9942623/aosp_arm64-userdebug/aosp_arm64-img-9942623.zip
    1451164060  2008-01-01 00:00   system.img

    aosp-android12-gsi/9942319/aosp_arm64-userdebug/aosp_arm64-img-9942319.zip
    1783685120  2008-01-01 00:00   system.img

    aosp-android13-gsi/9954174/aosp_arm64-userdebug/aosp_arm64-img-9954174.zip
    1909940224  2008-01-01 00:00   system.img

    aosp-master/9962505/aosp_arm64-userdebug/aosp_arm64-img-9962505.zip
    1926410240  2008-01-01 00:00   system.img